### PR TITLE
Change the runner keybinding to (shift)-Cmd-R.

### DIFF
--- a/keymaps/atom-runner.cson
+++ b/keymaps/atom-runner.cson
@@ -8,7 +8,7 @@
 # For more detailed documentation see
 # https://atom.io/docs/latest/advanced/keymaps
 '.platform-darwin .workspace .editor':
-  'cmd-r': 'runner:run'
+  'cmd-R': 'runner:run'
 
 '.platform-darwin .workspace':
   'ctrl-c': 'runner:stop'


### PR DESCRIPTION
Using cmd-r as the default keybinding will confuse people as cmd-r is a trivial core keybinding for most people coming to Atom from Sublime/Textmate. I hereby request that it is change to shift-cmd-R instead, as easy to hit as before, just non conflicting.
