### PR TITLE
Change the runner keybinding to Alt-R

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ can add more.
 
 ## Using
 
-* Hit Cmd+R to launch the runner for the active window.
+* Hit Alt+R to launch the runner for the active window.
 * Hit Ctrl+C to kill a currently running process.
 
 ## Configuring

--- a/keymaps/atom-runner.cson
+++ b/keymaps/atom-runner.cson
@@ -8,7 +8,7 @@
 # For more detailed documentation see
 # https://atom.io/docs/latest/advanced/keymaps
 '.platform-darwin .workspace .editor':
-  'cmd-r': 'runner:run'
+  'alt-r': 'runner:run'
 
 '.platform-darwin .workspace':
   'ctrl-c': 'runner:stop'


### PR DESCRIPTION
Both Cmd-R and Cmd-Shift-R (including Ctrl-r which is prepared for Windows/Linux versions) is occupied by the trivial core function "Show symbols in file/project". Some people may just end up uninstalling atom-runner for an easy fix when they finds out atom-runner has taken the cmd-r.
