### PR TITLE
Copy command in output view context menu

### DIFF
--- a/menus/atom-runner-view.cson
+++ b/menus/atom-runner-view.cson
@@ -1,0 +1,5 @@
+'context-menu':
+  '.atom-runner': [
+    {label: 'Copy', command: 'run:copy'}
+    {type: 'separator'}
+  ]


### PR DESCRIPTION
Added Copy command to Atom Runner's context menu.