### PR TITLE
Use activationCommands instead of deprecated activationEvents.

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,12 +8,8 @@
     "ansi-to-html": "0.1.x",
     "atom-space-pen-views": "^2.0.3"
   },
-  "activationEvents": [
-    "run:file",
-    "run:selection",
-    "run:stop",
-    "run:close",
-    "run:copy"
-  ],
+  "activationCommands": {
+    "atom-text-editor": ["run:file", "run:selection", "run:stop", "run:close", "run:copy"]
+  },
   "license": "MIT"
 }


### PR DESCRIPTION
Resolves the following message from Deprecation Cop:

---
Use `activationCommands` instead of `activationEvents` in your package.json
Commands should be grouped by selector as follows:
```json
  "activationCommands": {
    "atom-workspace": ["foo:bar", "foo:baz"],
    "atom-text-editor": ["foo:quux"]
  }
```
```
Package.getActivationCommands (/usr/share/atom/resources/app.asar/src/package.js:808:9)
Package.hasActivationCommands (/usr/share/atom/resources/app.asar/src/package.js:733:20)
<unknown> (/usr/share/atom/resources/app.asar/src/package.js:187:24)
Package.measure (/usr/share/atom/resources/app.asar/src/package.js:165:15)
Package.load (/usr/share/atom/resources/app.asar/src/package.js:179:12)
PackageManager.loadPackage (/usr/share/atom/resources/app.asar/src/package-manager.js:372:14)
```
