### PR TITLE
FIX: atom.project.path removed. Use atom.project.getPaths()

### DIFF
--- a/lib/atom-runner.coffee
+++ b/lib/atom-runner.coffee
@@ -136,7 +136,7 @@ class AtomRunner
       cmd = splitCmd[0]
       args = splitCmd.slice(1).concat(args)
     try
-      dir = atom.project.path || '.'
+      dir = atom.project.getPaths()[0] || '.'
       if not fs.statSync(dir).isDirectory()
         dir = p.dirname(dir)
       @child = spawn(cmd, args, cwd: dir)


### PR DESCRIPTION
atom.project.path has been removed from Atom API (due to multiple project support)
We should use atom.project.getPaths() instead

https://github.com/atom/atom/issues/5613