### PR TITLE
FIX : Uncaught TypeError: Cannot read property 'stdin' of undefined #101

### DIFF
--- a/lib/atom-runner.coffee
+++ b/lib/atom-runner.coffee
@@ -137,7 +137,10 @@ class AtomRunner
       args = splitCmd.slice(1).concat(args)
     try
       dir = atom.project.getPaths()[0] || '.'
-      if not fs.statSync(dir).isDirectory()
+      try
+        if not fs.statSync(dir).isDirectory()
+          throw new Error("Bad dir")
+      catch
         dir = p.dirname(dir)
       @child = spawn(cmd, args, cwd: dir)
       @child.on 'error', (err) =>


### PR DESCRIPTION
on Win10 atom.project.getPaths()[0] returns some bad path and fs.statSync throws an error.
statSync must be wrapped in try/catch to use p.dirname(dir) if "dir" doesn't exists.