### PR TITLE
Use tree-kill to properly stop forked child processes

### DIFF
--- a/lib/atom-runner.coffee
+++ b/lib/atom-runner.coffee
@@ -1,6 +1,7 @@
 {ConfigObserver} = require 'atom'
 
 spawn = require('child_process').spawn
+treekill = require('tree-kill')
 fs = require('fs')
 url = require('url')
 p = require('path')
@@ -114,7 +115,7 @@ class AtomRunner
         view.append('^C', 'stdin')
       else
         @debug('Killed child', child.pid)
-      @child.kill('SIGINT')
+      treekill(@child.pid, 'SIGINT')
       if @child.killed
         @child = null
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "repository": "https://github.com/lsegal/atom-runner",
   "dependencies": {
     "ansi-to-html": "0.1.x",
-    "atom-space-pen-views": "^2.0.3"
+    "atom-space-pen-views": "^2.0.3",
+    "tree-kill": "1.0.0"
   },
   "activationCommands": {
     "atom-text-editor": [


### PR DESCRIPTION
ChildProcess.kill() doesn't stop forked subprocesses. This commit uses [tree-kill](https://www.npmjs.com/package/tree-kill) to properly handle forked subprocesses on all platforms.