### PR TITLE
add command to run previously run editor

### DIFF
--- a/keymaps/atom-runner.cson
+++ b/keymaps/atom-runner.cson
@@ -10,10 +10,12 @@
 '.platform-darwin atom-text-editor':
   'ctrl-r': 'run:file'
   'ctrl-shift-r': 'run:selection'
+  'ctrl-q': 'run:prev'
 
 '.platform-win32 atom-text-editor, .platform-linux atom-text-editor':
   'alt-r': 'run:file'
   'alt-shift-r': 'run:selection'
+  'alt-q': 'run:prev'
 
 '.platform-darwin .atom-runner':
   'cmd-c': 'run:copy'

--- a/lib/atom-runner.coffee
+++ b/lib/atom-runner.coffee
@@ -36,6 +36,7 @@ class AtomRunner
 
   extensionMap: null
   scopeMap: null
+  prev: null
 
   debug: (args...) ->
     console.debug('[atom-runner]', args...)
@@ -70,11 +71,13 @@ class AtomRunner
     atom.commands.add 'atom-workspace', 'run:selection', => @run(true)
     atom.commands.add 'atom-workspace', 'run:stop', => @stop()
     atom.commands.add 'atom-workspace', 'run:close', => @stopAndClose()
+    atom.commands.add 'atom-workspace', 'run:prev', => @run(false, true)
     atom.commands.add '.atom-runner', 'run:copy', =>
       atom.clipboard.write(window.getSelection().toString())
 
-  run: (selection) ->
+  run: (selection, rerun=false) ->
     editor = atom.workspace.getActiveTextEditor()
+    editor = @prev if rerun
     return unless editor?
 
     path = editor.getPath()
@@ -104,6 +107,8 @@ class AtomRunner
     unless view.mocked
       view.setTitle(editor.getTitle())
       pane.activateItem(view)
+
+    @prev = editor
 
     @execute(cmd, editor, view, selection)
 

--- a/lib/atom-runner.coffee
+++ b/lib/atom-runner.coffee
@@ -36,6 +36,7 @@ class AtomRunner
 
   extensionMap: null
   scopeMap: null
+  prev: null
 
   debug: (args...) ->
     console.debug('[atom-runner]', args...)
@@ -70,11 +71,13 @@ class AtomRunner
     atom.commands.add 'atom-workspace', 'run:selection', => @run(true)
     atom.commands.add 'atom-workspace', 'run:stop', => @stop()
     atom.commands.add 'atom-workspace', 'run:close', => @stopAndClose()
+    atom.commands.add 'atom-workspace', 'run:prev', => @run(false, true)
     atom.commands.add '.atom-runner', 'run:copy', =>
       atom.clipboard.write(window.getSelection().toString())
 
-  run: (selection) ->
+  run: (selection, rerun=true) ->
     editor = atom.workspace.getActiveTextEditor()
+    editor = @prev if rerun
     return unless editor?
 
     path = editor.getPath()
@@ -104,6 +107,8 @@ class AtomRunner
     unless view.mocked
       view.setTitle(editor.getTitle())
       pane.activateItem(view)
+
+    @prev = editor
 
     @execute(cmd, editor, view, selection)
 

--- a/lib/atom-runner.coffee
+++ b/lib/atom-runner.coffee
@@ -75,7 +75,7 @@ class AtomRunner
     atom.commands.add '.atom-runner', 'run:copy', =>
       atom.clipboard.write(window.getSelection().toString())
 
-  run: (selection, rerun=true) ->
+  run: (selection, rerun=false) ->
     editor = atom.workspace.getActiveTextEditor()
     editor = @prev if rerun
     return unless editor?


### PR DESCRIPTION
When switching between files it is useful to be able to run the last run script without having to switch back to it.
