### PR TITLE
Support for macros in invokable command

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ below, which also represents the default configuration for this plugin:
 ```cson
 'runner':
   'scopes':
-    'coffee': 'coffee'
+    'coffee': 'coffee {FILE_ACTIVE}'
     'js': 'node'
     'ruby': 'ruby'
     'python': 'python'
@@ -113,7 +113,7 @@ steps to show the issue, please file a bug report. Please make sure that you pro
 detailed steps and include your environment (OS), language, and, if relevant, any
 source code you executed when running into the issue. Without this information,
 it is not always possible to know what is broken, and this will slow down the
-ability to provide a quick patch for any bugs. 
+ability to provide a quick patch for any bugs.
 
 Thanks for cooperating!
 

--- a/lib/atom-runner.coffee
+++ b/lib/atom-runner.coffee
@@ -85,6 +85,18 @@ class AtomRunner
     atom.commands.add '.atom-runner', 'run:copy', =>
       atom.clipboard.write(window.getSelection().toString())
 
+  translateMacros: (cmd) ->
+    editor = atom.workspace.getActiveTextEditor()
+    return cmd unless editor?
+
+    cmd
+      .replace('{FILE_ACTIVE}', editor.getPath())
+      # .replace('{FILE_ACTIVE_PATH}', TODO)
+      # .replace('{FILE_ACTIVE_NAME}', TODO)
+      # .replace('{FILE_ACTIVE_NAME_BASE}', TODO)
+      # .replace('{FILE_ACTIVE_PATH}', TODO)
+      # .replace('{PROJECT_PATH}', TODO)
+
   run: (selection) ->
     editor = atom.workspace.getActiveTextEditor()
     return unless editor?
@@ -94,6 +106,8 @@ class AtomRunner
     unless cmd?
       console.warn("No registered executable for file '#{path}'")
       return
+
+    cmd = @translateMacros(cmd)
 
     if atom.config.get('atom-runner.showOutputWindow')
       {pane, view} = @runnerView()


### PR DESCRIPTION
My patch implements support for the FILE_ACTIVE macro (shamelessly stolen from the script package at https://github.com/rgbkrk/atom-script which I wasn't able to configure properly and consistently).

FIY
This is my first attempt hacking inside the atom ecosphere which is why I haven't made the effort of implementing more macros (also this macro is the only one I currently need).