### PR TITLE
Added -webkit-user-select

### DIFF
--- a/styles/atom-runner.less
+++ b/styles/atom-runner.less
@@ -7,6 +7,7 @@
 .atom-runner {
   background: @base-background-color;
   padding: @component-padding;
+  -webkit-user-select: none;
 
   overflow-y: scroll;
   color: @text-color;
@@ -14,7 +15,9 @@
   pre {
     background-color: @input-background-color;
     padding: (@component-padding + 5);
-
+    .output {
+      -webkit-user-select: initial;
+    }
     .stderr { color: @text-color-error; }
   }
 


### PR DESCRIPTION
I have added 
```
.atom-runner {
    -webkit-user-select: none;
}
.atom-runner pre {
    -webkit-user-select: initial;
}
```
which first disables option to select anything within the package area. Then for the pre area it enables the option to select the generated output.

This allows you to generate output and copy and paste it somewhere.

Ideally you should instead add a button to copy the output to clipboard.