### PR TITLE
change interval counter display

### DIFF
--- a/lib/atom-runner.coffee
+++ b/lib/atom-runner.coffee
@@ -160,7 +160,7 @@ class AtomRunner
       catch
         dir = p.dirname(dir)
       @child = spawn(cmd, args, cwd: dir)
-      @timer = setInterval((=> view.appendFooter('.')), 750)
+      @timer = setInterval((=> view.appendFooter(' . ')), 750)
       currentPid = @child.pid
       @child.on 'error', (err) =>
         if err.message.match(/\bENOENT$/)


### PR DESCRIPTION
on long processes the counter dots are not wrapped and make huge horizontal scrolling to see exit status
adding space fixes this and atom can properly wrap text (and i think it looks nicer :)
