### PR TITLE
Add command to run previously run editor

### DIFF
--- a/keymaps/atom-runner.cson
+++ b/keymaps/atom-runner.cson
@@ -10,10 +10,12 @@
 '.platform-darwin atom-text-editor':
   'ctrl-r': 'run:file'
   'ctrl-shift-r': 'run:selection'
+  'ctrl-q': 'run:prev'
 
 '.platform-win32 atom-text-editor, .platform-linux atom-text-editor':
   'alt-r': 'run:file'
   'alt-shift-r': 'run:selection'
+  'alt-q': 'run:prev'
 
 '.platform-darwin .atom-runner':
   'cmd-c': 'run:copy'

--- a/lib/atom-runner.coffee
+++ b/lib/atom-runner.coffee
@@ -88,7 +88,7 @@ class AtomRunner
     atom.commands.add '.atom-runner', 'run:copy', =>
       atom.clipboard.write(window.getSelection().toString())
 
-  run: (selection, rerun=true) ->
+  run: (selection, rerun=false) ->
     editor = atom.workspace.getActiveTextEditor()
     editor = @prev if rerun
     return unless editor?

--- a/lib/atom-runner.coffee
+++ b/lib/atom-runner.coffee
@@ -49,6 +49,7 @@ class AtomRunner
     Left: 'splitLeft'
     Up: 'splitUp'
     Down: 'splitDown'
+  prev: null
 
   debug: (args...) ->
     console.debug('[atom-runner]', args...)
@@ -83,11 +84,13 @@ class AtomRunner
     atom.commands.add 'atom-workspace', 'run:selection', => @run(true)
     atom.commands.add 'atom-workspace', 'run:stop', => @stop()
     atom.commands.add 'atom-workspace', 'run:close', => @stopAndClose()
+    atom.commands.add 'atom-workspace', 'run:prev', => @run(false, true)
     atom.commands.add '.atom-runner', 'run:copy', =>
       atom.clipboard.write(window.getSelection().toString())
 
-  run: (selection) ->
+  run: (selection, rerun=true) ->
     editor = atom.workspace.getActiveTextEditor()
+    editor = @prev if rerun
     return unless editor?
 
     path = editor.getPath()
@@ -119,6 +122,8 @@ class AtomRunner
     unless view.mocked
       view.setTitle(editor.getTitle())
       pane.activateItem(view)
+
+    @prev = editor
 
     @execute(cmd, editor, view, selection)
 

--- a/lib/atom-runner.coffee
+++ b/lib/atom-runner.coffee
@@ -50,6 +50,7 @@ class AtomRunner
     Up: 'splitUp'
     Down: 'splitDown'
   prev: null
+  prevWasSelection: false
 
   debug: (args...) ->
     console.debug('[atom-runner]', args...)
@@ -92,6 +93,8 @@ class AtomRunner
     editor = atom.workspace.getActiveTextEditor()
     editor = @prev if rerun
     return unless editor?
+    
+    selection = @prevWasSelection if rerun
 
     path = editor.getPath()
     cmd = @commandFor(editor, selection)
@@ -124,6 +127,7 @@ class AtomRunner
       pane.activateItem(view)
 
     @prev = editor
+    @prevWasSelection = selection
 
     @execute(cmd, editor, view, selection)
 


### PR DESCRIPTION
Improved #119 by adding support for selection runs.

> What if the previous run was a run:selection? The implementation should be robust enough to support any previous execution.